### PR TITLE
Correct stop() behavior

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -495,9 +495,7 @@ class PianobarSkill(MycroftSkill):
             self.handle_resume_song()
 
     def stop(self):
-        LOG.info('STOPPING PANDORA')
-        if not self.piano_bar_state == "paused":
-            LOG.info('YES')
+        if self.piano_bar_state and not self.piano_bar_state == "paused":
             self.handle_pause()
             self.enclosure.mouth_reset()
             return True


### PR DESCRIPTION
The stop() command was always triggering by default due to self.piano_bar_state initialization to None.