### PR TITLE
Fail if requirements.sh doesn't find pianobar

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -12,4 +12,10 @@ if found_exe pkcon; then
     pkcon install pianobar -y
 fi
 
-exit 0
+if found_exe pianobar; then
+    exit 0
+else
+    echo "Could not find pianobar! Please install with your package manager."
+    exit 1
+fi
+


### PR DESCRIPTION
For users that need to manually install pianobar, its helpful to have it fail so that it will notify them they need to perform a manual step first. It only fails if the `pianobar` executable isn't found as an executable.