### PR TITLE
add install command to pkcon

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -14,7 +14,7 @@ found_exe() {
 if found_exe pkcon; then
     # pkcon is a high-level front end for many package manager technologies,
     # prefer this if it exists.
-    pm="pkcon"
+    pm="pkcon -y install"
 else
     priv="sudo"
 


### PR DESCRIPTION
Currently running `mycroft-msm install pandora` fails on my Debian Stretch install with the following output:
```
INFO - Best match (0.9): mycroft-pandora by MycroftAI
INFO - Downloading skill: https://github.com/MycroftAI/pianobar-skill
Command failed: Option 'pianobar' is not supported
Could not find pianobar! Please install with your package manager.
ERROR - Requirements.sh failed with error code: 1
INFO - Problem performing action. Restoring skill to previous state...
SystemRequirementsException: 1
```

If `pkcon` is found it assigns `pm` to be `pkcon` which makes sense if `pm` is just the "package manager" however this variable seems to really be the "package manager installation command".

Currently this results in the script attempting to run `pkcon pianobar` instead of `pkcon install pianobar`. Hence needs to at least have the install command added. To be consistent with the pacman, apt and zypper versions I also added a `-y` flag.

**To test:**
1. ensure you are on a system with pkcon
2. uninstall pianobar
3. run the old requirements.sh - installation should fail
4. run the new script - pianobar should successfully install
