### PR TITLE
Allow skipping while paused

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -505,7 +505,7 @@ class PianobarSkill(CommonPlaySkill):
             self.speak_dialog("please.register.pandora")
 
     def handle_next_song(self, message=None):
-        if self.process and self.piano_bar_state == "playing":
+        if self.process:
             self.enclosure.mouth_think()
             self.cmd("n")
             self.piano_bar_state = "playing"


### PR DESCRIPTION
There's really no reason it should have to be playing to skip, _especially_ because _the state is set to autopause when you say the wake word!_ As is, saying "skip song" is nearly useless because it's _never_ in the playing state, and either way you shouldn't have to do two separate commands (WAKE WORD, resume; WAKE WORD, next song).