### PR TITLE
Fix settings won't sync on core v20.8.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -96,6 +96,7 @@ class PianobarSkill(CommonPlaySkill):
         self.settings_change_callback = self.on_websettings_changed
         self.on_websettings_changed()
         self.add_event("mycroft.stop", self.stop)
+        self.log.exception("Failed to connect to Pandora: ")
 
     def CPS_match_query_phrase(self, phrase):
         if not self._is_setup:
@@ -342,7 +343,7 @@ class PianobarSkill(CommonPlaySkill):
             self.play_info["first_init"] = False
             self._load_current_info()
         except Exception as e:
-            self.log.exception("Failed to connect to Pandora: " + repr(e))
+            self.log.exception("Failed to connect to Pandora: ")
             self.troubleshoot_auth_error()
 
         self.process = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 fuzzywuzzy==0.15.0
+json_database==0.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fuzzywuzzy==0.15.0
+fuzzywuzzy==0.18.0
 json_database==0.5.5


### PR DESCRIPTION
As reported in https://github.com/MycroftAI/mycroft-core/issues/2842

The Skill settings stopped syncing due to the Skill storing information on currently and recently played items in the Skill settings object.

This moves all values that are not Skill settings to a local json database stored in the Skills namespaced filesystem.

An auto-format and small import clean up was also done. 

FuzzyWuzzy has been updated to incorporate [fixes for Python3.7](https://github.com/seatgeek/fuzzywuzzy/releases/tag/0.18.0).

### To Test
- Ensure you are running mycroft-core 20.8.1 (or latest dev branch)
- Install new version of Skill - if switching branches ensure you get the new dependencies
  ```
  mycroft-pip install -r /opt/mycroft/skills/mycroft-pandora.mycroftai/requirements.txt
  ```
- Delete any existing settings.json
- Reboot Mycroft.

